### PR TITLE
STY: change nobs2 to nobs0 for consistency in `score_test_proportions_2indep`

### DIFF
--- a/statsmodels/stats/proportion.py
+++ b/statsmodels/stats/proportion.py
@@ -1555,7 +1555,7 @@ def score_test_proportions_2indep(count1, nobs1, count2, nobs2, value=None,
 
         if ratio != 1:
             a = nobs * ratio
-            b = -(nobs1 * ratio + count1 + nobs2 + count0 * ratio)
+            b = -(nobs1 * ratio + count1 + nobs0 + count0 * ratio)
             c = count
             prop0 = (-b - np.sqrt(b**2 - 4 * a * c)) / (2 * a)
             prop1 = prop0 * ratio


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed. 
- [ ] code/documentation is well formatted.  
- [ ] properly formatted commit message. See 
      [NumPy's guide](https://docs.scipy.org/doc/numpy-1.15.1/dev/gitwash/development_workflow.html#writing-the-commit-message). 

This is a very simple PR which **does not** change functionality of the code whatsoever, just fixes something I found confusing while reading the code. 

For consistency with the paper the code is based on, the [function switches](https://github.com/statsmodels/statsmodels/blob/140f8341da33c064ff6f2e51dedc9428ba249fa4/statsmodels/stats/proportion.py#L1526) `counts2, nobs2` to `counts0, nobs0`. It looks like there was one place this change was missed later in the function, which I just found confusing while reading the code. 

